### PR TITLE
Make LINKSWAP name consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LinkSwap
+# LINKSWAP
 
 # Local Development
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "linkswap",
   "version": "1.0.0",
-  "description": "LinkSwap smart contracts",
+  "description": "LINKSWAP smart contracts",
   "license": "UNLICENSED",
   "homepage": "https://yflink.io/",
   "keywords": [


### PR DESCRIPTION
Minor changes to bring the LINKSWAP name in line with branding.

**Note:** I have not changed the name in `LinkswapPair.sol#L16` as I do not know whether this would cause issues with the existing contracts deployed on Ethereum. If not then it's obviously an easy edit.